### PR TITLE
Add the possibility to have consistent uid for aptly user

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -16,12 +16,19 @@
     update_cache : True
     state : 'present'
 
-- name : Create aptly user
+- name: Ensure aptly group
+  become : True
+  group:
+    name: "{{ aptly_group }}"
+    gid: "{{ aptly_gid | default(omit) }}"
+
+- name : Ensure aptly user
   become : True
   user :
     name : "{{ aptly_user }}"
     comment : 'User for aptly repository management'
     home : "{{ aptly_user_home }}"
+    group: "{{ aptly_group }}"
     shell : '/bin/bash'
     uid: "{{ aptly_uid | default(omit) }}"
 

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -23,6 +23,7 @@
     comment : 'User for aptly repository management'
     home : "{{ aptly_user_home }}"
     shell : '/bin/bash'
+    uid: "{{ aptly_uid | default(omit) }}"
 
 - name : Change home permission
   become : True


### PR DESCRIPTION
If someone needs to recreate aptly over and over again, he would
probably want to have full consistency and control over the uid
used by aptly.

This patch adds the possibility to define aptly_uid. If defined,
the uid of aptly user will be set, if not the current behavior is
unchanged.