### PR TITLE
Ensure consistency of the become

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 
 # Defaults file for aptly
 
+aptly_become_method: "sudo"
+
 # Custom gpg key
 aptly_custom_gpg_key_file : False
 aptly_custom_gpg_key_id   : False

--- a/tasks/archive_gpg_keys.yml
+++ b/tasks/archive_gpg_keys.yml
@@ -5,7 +5,7 @@
 - name: Export system archive GPG keys
   become: True
   become_user: "{{ aptly_user }}"
-  become_method: "sudo"
+  become_method: "{{ aptly_become_method }}"
   command: >
     gpg --no-default-keyring --keyring
     /usr/share/keyrings/{{ ansible_distribution | lower }}-archive-keyring.gpg
@@ -16,7 +16,7 @@
 - name: Import system archive GPG keys
   become: True
   become_user: "{{ aptly_user }}"
-  become_method: "sudo"
+  become_method: "{{ aptly_become_method }}"
   command: >
     gpg --no-default-keyring
     --keyring {{ aptly_system_archive_gpg_keys_keyring }} --import

--- a/tasks/archive_gpg_keys.yml
+++ b/tasks/archive_gpg_keys.yml
@@ -4,19 +4,23 @@
 
 - name: Export system archive GPG keys
   become: True
-  shell: >
-    su - {{ aptly_user }} -c 'gpg --no-default-keyring --keyring
+  become_user: "{{ aptly_user }}"
+  become_method: "sudo"
+  command: >
+    gpg --no-default-keyring --keyring
     /usr/share/keyrings/{{ ansible_distribution | lower }}-archive-keyring.gpg
-    --export --output /tmp/{{ aptly_system_archive_gpg_keys_keyring }}'
+    --export --output /tmp/{{ aptly_system_archive_gpg_keys_keyring }}
   changed_when: False
   when: "{{ aptly_system_archive_gpg_keys_import == True }}"
 
 - name: Import system archive GPG keys
   become: True
-  shell: >
-    su - {{ aptly_user }} -c 'gpg --no-default-keyring
+  become_user: "{{ aptly_user }}"
+  become_method: "sudo"
+  command: >
+    gpg --no-default-keyring
     --keyring {{ aptly_system_archive_gpg_keys_keyring }} --import
-    /tmp/{{ aptly_system_archive_gpg_keys_keyring }}'
+    /tmp/{{ aptly_system_archive_gpg_keys_keyring }}
   register: aptly_archive_gpg_keys_added
   changed_when: False
   when: "{{ aptly_system_archive_gpg_keys_import == True }}"

--- a/tasks/custom_gpg_key.yml
+++ b/tasks/custom_gpg_key.yml
@@ -27,9 +27,8 @@
 - name : Import custom gpg key
   become : True
   become_user : "{{ aptly_user }}"
-  shell : >
-    gpg
-    --allow-secret-key-import
+  command: >
+    gpg --allow-secret-key-import
     --import /tmp/{{ aptly_custom_gpg_key_file | basename }}
   when : custom_gpg_check.stdout.find(aptly_custom_gpg_key_id) == -1
 

--- a/tasks/mirror_management.yml
+++ b/tasks/mirror_management.yml
@@ -4,18 +4,21 @@
 
 - name: List available mirrors
   become: True
-  shell: >
-    su - {{ aptly_user }} -c 'aptly mirror list -raw'
+  become_user: "{{ aptly_user }}"
+  become_method: "sudo"
+  command: aptly mirror list -raw
   changed_when: False
   register: aptly_mirrors_list
 
 - name: Import mirror target GPG keys
   become: True
-  shell: >
-    su - {{ aptly_user }} -c 'gpg --no-default-keyring
+  become_user: "{{ aptly_user }}"
+  become_method: "sudo"
+  command: >
+    gpg --no-default-keyring
     --keyserver {{ item.gpg.server }}
     --keyring {{ item.gpg.keyring }}
-    --recv-keys {{ item.gpg.key }}'
+    --recv-keys {{ item.gpg.key }}
   register: aptly_mirror_target_gpg_keys_added
   changed_when: false
   with_items: "{{ aptly_mirrors }}"
@@ -35,8 +38,9 @@
 
 - name: Remove mirrors
   become: True
-  shell: >
-    su - {{ aptly_user }} -c 'aptly mirror drop {{ item.name }}'
+  become_user: "{{ aptly_user }}"
+  become_method: "sudo"
+  command: "aptly mirror drop {{ item.name }}"
   register: aptly_mirrors_removed
   notify: "Clean aptly database"
   with_items: "{{ aptly_mirrors }}"
@@ -46,11 +50,13 @@
 
 - name: Create mirrors
   become: True
-  shell: >
-    su - {{ aptly_user }} -c 'aptly mirror create
+  become_user: "{{ aptly_user }}"
+  become_method: "sudo"
+  command: >
+    aptly mirror create
     {{ item.create_flags | join(" ") }}
     {{ item.name }} "{{ item.archive_url }}"
-    {{ item.distribution }} {{ item.component1 | join(" ") }}'
+    {{ item.distribution }} {{ item.component1 | join(" ") }}
   register: aptly_mirrors_created
   with_items: "{{ aptly_mirrors }}"
   when:
@@ -59,10 +65,11 @@
 
 - name: Update mirrors
   become: True
-  shell: >
-    su - {{ aptly_user }}
-    -c 'aptly mirror update {{ item.update_flags | join(" ") }}
-    {{ item.name }}'
+  become_user: "{{ aptly_user }}"
+  become_method: "sudo"
+  command: >
+    aptly mirror update {{ item.update_flags | join(" ") }}
+    {{ item.name }}
   with_items: "{{ aptly_mirrors }}"
   when:
     - "{{ item.state == 'present' }}"

--- a/tasks/mirror_management.yml
+++ b/tasks/mirror_management.yml
@@ -5,7 +5,7 @@
 - name: List available mirrors
   become: True
   become_user: "{{ aptly_user }}"
-  become_method: "sudo"
+  become_method: "{{ aptly_become_method }}"
   command: aptly mirror list -raw
   changed_when: False
   register: aptly_mirrors_list
@@ -13,7 +13,7 @@
 - name: Import mirror target GPG keys
   become: True
   become_user: "{{ aptly_user }}"
-  become_method: "sudo"
+  become_method: "{{ aptly_become_method }}"
   command: >
     gpg --no-default-keyring
     --keyserver {{ item.gpg.server }}
@@ -39,7 +39,7 @@
 - name: Remove mirrors
   become: True
   become_user: "{{ aptly_user }}"
-  become_method: "sudo"
+  become_method: "{{ aptly_become_method }}"
   command: "aptly mirror drop {{ item.name }}"
   register: aptly_mirrors_removed
   notify: "Clean aptly database"
@@ -51,7 +51,7 @@
 - name: Create mirrors
   become: True
   become_user: "{{ aptly_user }}"
-  become_method: "sudo"
+  become_method: "{{ aptly_become_method }}"
   command: >
     aptly mirror create
     {{ item.create_flags | join(" ") }}
@@ -66,7 +66,7 @@
 - name: Update mirrors
   become: True
   become_user: "{{ aptly_user }}"
-  become_method: "sudo"
+  become_method: "{{ aptly_become_method }}"
   command: >
     aptly mirror update {{ item.update_flags | join(" ") }}
     {{ item.name }}

--- a/tasks/repo_management.yml
+++ b/tasks/repo_management.yml
@@ -4,15 +4,17 @@
 
 - name: List available repos
   become: True
-  shell: >
-    su - {{ aptly_user }} -c 'aptly repo list -raw'
+  become_user: "{{ aptly_user }}"
+  become_method: "sudo"
+  command: aptly repo list -raw
   changed_when: False
   register: aptly_repos_list
 
 - name: Remove repos
   become: True
-  shell: >
-    su - {{ aptly_user }} -c 'aptly repo drop {{ item.name }}'
+  become_user: "{{ aptly_user }}"
+  become_method: "sudo"
+  command: "aptly repo drop {{ item.name }}"
   register: aptly_repos_removed
   notify: "Clean aptly database"
   with_items: "{{ aptly_repos }}"
@@ -22,10 +24,11 @@
 
 - name: Create repos
   become: True
-  shell: >
-    su - {{ aptly_user }} -c 'aptly repo create
-    {{ item.create_flags | join(" ") }}
-    {{ item.name }}'
+  become_user: "{{ aptly_user }}"
+  become_method: "sudo"
+  command: >
+    aptly repo create {{ item.create_flags | join(" ") }}
+    {{ item.name }}
   register: aptly_repos_created
   with_items: "{{ aptly_repos }}"
   when:

--- a/tasks/repo_management.yml
+++ b/tasks/repo_management.yml
@@ -5,7 +5,7 @@
 - name: List available repos
   become: True
   become_user: "{{ aptly_user }}"
-  become_method: "sudo"
+  become_method: "{{ aptly_become_method }}"
   command: aptly repo list -raw
   changed_when: False
   register: aptly_repos_list
@@ -13,7 +13,7 @@
 - name: Remove repos
   become: True
   become_user: "{{ aptly_user }}"
-  become_method: "sudo"
+  become_method: "{{ aptly_become_method }}"
   command: "aptly repo drop {{ item.name }}"
   register: aptly_repos_removed
   notify: "Clean aptly database"
@@ -25,7 +25,7 @@
 - name: Create repos
   become: True
   become_user: "{{ aptly_user }}"
-  become_method: "sudo"
+  become_method: "{{ aptly_become_method }}"
   command: >
     aptly repo create {{ item.create_flags | join(" ") }}
     {{ item.name }}


### PR DESCRIPTION
In some tasks we have become and become_user, while in other there
is su - {{ user }} -c. This could just be replaced by become,
become_user and become_method.

On top of that, the shell isn't necessary anymore, and command can
be used instead. That way it will not be the cause of ansible-lint
issues.