### PR TITLE
Use variable for home directory mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ aptly_system_archive_gpg_keys_keyring: 'system-trusted.gpg'
 aptly_user: 'aptly'
 aptly_group: 'aptly'
 aptly_user_home: '/var/lib/aptly'
+aptly_user_home_mode: 0700
 
 # Software settings
 aptly_version: '0.9.6'

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -41,7 +41,7 @@
   become: True
   file:
     dest: "{{ aptly_user_home }}"
-    mode: '0700'
+    mode: "{{ aptly_user_home_mode }}"
 
 
 - name: 'INSTALL | APT | Install aptly package'


### PR DESCRIPTION
Hi,

Hardcoded 0700 mode is restrictive. In my case, i want to allow `www-data` to cross it. Would you mind making it a variable ?

Thanks for the role.

Regards,
Étienne