### PR TITLE
Drop Jinja template delimiters in when stanzas

### DIFF
--- a/tasks/archive_gpg_keys.yml
+++ b/tasks/archive_gpg_keys.yml
@@ -9,7 +9,7 @@
     /usr/share/keyrings/{{ ansible_distribution | lower }}-archive-keyring.gpg
     --export --output /tmp/{{ aptly_system_archive_gpg_keys_keyring }}'
   changed_when: False
-  when: "{{ aptly_system_archive_gpg_keys_import == True }}"
+  when: "aptly_system_archive_gpg_keys_import == True"
 
 
 - name: 'GPG | SYSTEM | Import system archive GPG keys'
@@ -20,7 +20,7 @@
     /tmp/{{ aptly_system_archive_gpg_keys_keyring }}'
   register: 'aptly_archive_gpg_keys_added'
   changed_when: False
-  when: "{{ aptly_system_archive_gpg_keys_import == True }}"
+  when: "aptly_system_archive_gpg_keys_import == True"
 
 
 - name: 'GPG | SYSTEM | Remove temp archive gpg export'
@@ -35,6 +35,6 @@
   debug:
     msg: "{{ aptly_archive_gpg_keys_added.stderr.split('\n') }}"
   when:
-    - "{{ aptly_system_archive_gpg_keys_import == True }}"
-    - "{{ aptly_archive_gpg_keys_added.stderr is defined }}"
-    - "{{ aptly_archive_gpg_keys_added.stderr.find(' changed:') != -1 }}"
+    - "aptly_system_archive_gpg_keys_import == True"
+    - "aptly_archive_gpg_keys_added.stderr is defined"
+    - "aptly_archive_gpg_keys_added.stderr.find(' changed:') != -1"

--- a/tasks/custom_gpg_key.yml
+++ b/tasks/custom_gpg_key.yml
@@ -4,8 +4,8 @@
 
 - fail:
     msg: 'A custom gpg key should be defined'
-  when: "{{ (aptly_custom_gpg_key_file == False)
-              or (aptly_custom_gpg_key_id == False) }}"
+  when: "(aptly_custom_gpg_key_file == False)
+              or (aptly_custom_gpg_key_id == False)"
 
 
 - name: 'GPG | CUSTOM | Check if key already imported'
@@ -24,7 +24,7 @@
     owner: "{{ aptly_user }}"
     group: "{{ aptly_user }}"
     mode: '0400'
-  when: "{{ custom_gpg_check.stdout.find(aptly_custom_gpg_key_id) == -1 }}"
+  when: "custom_gpg_check.stdout.find(aptly_custom_gpg_key_id) == -1"
 
 
 - name: 'GPG | CUSTOM | Import key'
@@ -34,7 +34,7 @@
     gpg
     --allow-secret-key-import
     --import /tmp/{{ aptly_custom_gpg_key_file | basename }}
-  when: "{{ custom_gpg_check.stdout.find(aptly_custom_gpg_key_id) == -1 }}"
+  when: "custom_gpg_check.stdout.find(aptly_custom_gpg_key_id) == -1"
 
 
 - name: 'GPG | CUSTOM | Remove key file'
@@ -42,4 +42,4 @@
   file:
     path: "/tmp/{{ aptly_custom_gpg_key_file | basename }}"
     state: 'absent'
-  when: "{{ custom_gpg_check.stdout.find(aptly_custom_gpg_key_id) == -1 }}"
+  when: "custom_gpg_check.stdout.find(aptly_custom_gpg_key_id) == -1"

--- a/tasks/mirror_management.yml
+++ b/tasks/mirror_management.yml
@@ -21,19 +21,19 @@
   changed_when: false
   with_items: "{{ aptly_mirrors }}"
   when:
-    - "{{ item.state == 'present' }}"
-    - "{{ item.gpg is defined }}"
-    - "{{ (item.gpg.key is defined) and (item.gpg.key != '') }}"
-    - "{{ (item.gpg.server is defined) and (item.gpg.server != '') }}"
-    - "{{ (item.gpg.keyring is defined) and (item.gpg.keyring != '') }}"
+    - "item.state == 'present'"
+    - "item.gpg is defined"
+    - "(item.gpg.key is defined) and (item.gpg.key != '')"
+    - "(item.gpg.server is defined) and (item.gpg.server != '')"
+    - "(item.gpg.keyring is defined) and (item.gpg.keyring != '')"
 
 
 - name: 'CONFIG | MIRRORS | Check if new GPG key managed'
   command: 'echo "New GPG key"'
   with_items: "{{ aptly_mirror_target_gpg_keys_added.results }}"
   when:
-    - "{{ item.stderr is defined }}"
-    - "{{ item.stderr.find(' changed: 1') != -1 }}"
+    - "item.stderr is defined"
+    - "item.stderr.find(' changed: 1') != -1"
 
 
 - name: 'CONFIG | MIRRORS | Remove mirrors'
@@ -44,8 +44,8 @@
   notify: "HANDLER | Clean aptly database"
   with_items: "{{ aptly_mirrors }}"
   when:
-    - "{{ item.state == 'absent' }}"
-    - "{{ item.name in aptly_mirrors_list.stdout_lines }}"
+    - "item.state == 'absent'"
+    - "item.name in aptly_mirrors_list.stdout_lines"
 
 
 - name: 'CONFIG | MIRRORS | Create mirrors'
@@ -58,8 +58,8 @@
   register: 'aptly_mirrors_created'
   with_items: "{{ aptly_mirrors }}"
   when:
-    - "{{ item.state == 'present' }}"
-    - "{{ item.name not in aptly_mirrors_list.stdout_lines }}"
+    - "item.state == 'present'"
+    - "item.name not in aptly_mirrors_list.stdout_lines"
 
 
 - name: 'CONFIG | MIRRORS | Update mirrors'
@@ -70,5 +70,5 @@
     {{ item.name }}'
   with_items: "{{ aptly_mirrors }}"
   when:
-    - "{{ item.state == 'present' }}"
-    - "{{ item.do_update == True }}"
+    - "item.state == 'present'"
+    - "item.do_update == True"

--- a/tasks/repo_management.yml
+++ b/tasks/repo_management.yml
@@ -18,8 +18,8 @@
   notify: "HANDLER | Clean aptly database"
   with_items: "{{ aptly_repos }}"
   when:
-    - "{{ item.state == 'absent' }}"
-    - "{{ item.name in aptly_repos_list.stdout_lines }}"
+    - "item.state == 'absent'"
+    - "item.name in aptly_repos_list.stdout_lines"
 
 
 - name: 'CONFIG | REPOS | Create repos'
@@ -31,5 +31,5 @@
   register: 'aptly_repos_created'
   with_items: "{{ aptly_repos }}"
   when:
-    - "{{ item.state == 'present' }}"
-    - "{{ item.name not in aptly_repos_list.stdout_lines }}"
+    - "item.state == 'present'"
+    - "item.name not in aptly_repos_list.stdout_lines"


### PR DESCRIPTION
Using `infOpen.aptly` triggers a load of warnings about *inja2 delimiters* in conditions. This PR clean these warnings.

Fixes:

    [WARNING]: when statements should not include jinja2 templating delimite...
