### PR TITLE
Make `create_flags` and `update_flags` optional

### DIFF
--- a/tasks/mirror_management.yml
+++ b/tasks/mirror_management.yml
@@ -52,7 +52,7 @@
   become: True
   shell: >
     su - {{ aptly_user }} -c 'aptly mirror create
-    {{ item.create_flags | join(" ") }}
+    {% if item.create_flags is defined -%} {{ item.create_flags | join(" ") }} {% endif -%}
     {{ item.name }} "{{ item.archive_url }}"
     {{ item.distribution }} {{ item.component1 | join(" ") }}'
   register: 'aptly_mirrors_created'
@@ -66,7 +66,8 @@
   become: True
   shell: >
     su - {{ aptly_user }}
-    -c 'aptly mirror update {{ item.update_flags | join(" ") }}
+    -c 'aptly mirror update
+    {% if item.update_flags is defined -%} {{ item.update_flags | join(" ") }} {% endif -%}
     {{ item.name }}'
   with_items: "{{ aptly_mirrors }}"
   when:

--- a/tasks/repo_management.yml
+++ b/tasks/repo_management.yml
@@ -26,7 +26,7 @@
   become: True
   shell: >
     su - {{ aptly_user }} -c 'aptly repo create
-    {{ item.create_flags | join(" ") }}
+    {% if item.create_flags is defined -%} {{ item.create_flags | join(" ") }} {% endif -%}
     {{ item.name }}'
   register: 'aptly_repos_created'
   with_items: "{{ aptly_repos }}"


### PR DESCRIPTION
Those options are optional to aptly and should therefore be optional in the ansible role as well.