### PR TITLE
Use new GPG key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,14 @@ script:
 
   # Run the role/playbook with ansible-playbook.
   - >
+    ANSIBLE_CONFIG=tests/ansible.cfg
     ansible-playbook -i tests/inventory ./testing_deployment.yml
     --skip-tags='role::aptly::custom-gpg' --connection=local --sudo
 
   # Run the role/playbook again, checking to make sure it's idempotent.
   # Check change == 1 due to mirror update
   - >
+    ANSIBLE_CONFIG=tests/ansible.cfg
     ansible-playbook -i tests/inventory ./testing_deployment.yml
     --skip-tags='role::aptly::custom-gpg' --connection=local --sudo
     | grep -q 'changed=[1].*failed=0'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ aptly_user_home_mode: 0700
 aptly_version: '0.9.6'
 aptly_activate_api: False
 aptly_gpg_key: 'ED75B5A4483DA07C'
-aptly_gpg_keyserver: 'hkp://keys.gnupg.net'
+aptly_gpg_keyserver: 'hkp://pool.sks-keyservers.net'
 aptly_repository: 'deb http://repo.aptly.info/ squeeze main'
 aptly_repository_file_mode: '0644'
 aptly_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ aptly_user_home_mode: 0700
 # Software settings
 aptly_version: '0.9.6'
 aptly_activate_api: False
-aptly_gpg_key: '9E3E53F19C7DE460'
+aptly_gpg_key: 'ED75B5A4483DA07C'
 aptly_gpg_keyserver: 'hkp://keys.gnupg.net'
 aptly_repository: 'deb http://repo.aptly.info/ squeeze main'
 aptly_repository_file_mode: '0644'

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+# Required to connect as non root and become aptly user.
+allow_world_readable_tmpfiles = True
+
+[ssh_connection]
+pipelining = True

--- a/tests/testinfra/test_installation.py
+++ b/tests/testinfra/test_installation.py
@@ -91,7 +91,7 @@ def test_packages(Package):
     package = Package('aptly')
 
     assert package.is_installed
-    assert '0.9.7' in package.version
+    assert package.version > '1.'
 
 
 def test_aptly_mirror_management(Command):


### PR DESCRIPTION
Official repository GPG key has expired on 2018-03-15. This PR register the new GPG key as default.

``` console
root@aptly:~# apt-key list smira
pub   rsa2048 2016-03-15 [SC] [expired: 2018-03-15]
      DF32 BC15 E214 5B3F A151  AED1 9E3E 53F1 9C7D E460
uid           [ expired] Andrey Smirnov <me@smira.ru>

pub   rsa4096 2018-03-15 [SC] [expires: 2020-03-14]
      26DA 9D86 3030 2E0B 86A7  A2CB ED75 B5A4 483D A07C
uid           [ unknown] Andrey Smirnov <me@smira.ru>
sub   rsa4096 2018-03-15 [E] [expires: 2020-03-14]
```